### PR TITLE
using sync map instead of manually using mutex with a regular map !

### DIFF
--- a/csv_report.go
+++ b/csv_report.go
@@ -5,36 +5,52 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 )
 
-func writeCSVReport(pages map[string]PageData, filename string) error {
-
+func writeCSVReport(pages *sync.Map, filename string) error {
 	file, err := os.Create(filename)
 	if err != nil {
 		fmt.Println("Error creating file:", err)
 		return err
 	}
+	defer file.Close()
 
 	csvWriter := csv.NewWriter(file)
 	defer csvWriter.Flush()
 
+	// Write header
 	err = csvWriter.Write([]string{"page_url", "h1", "first_paragraph", "outgoing_link_urls", "image_urls"})
 	if err != nil {
 		fmt.Printf("Error writing header to csv file: %v", err)
 		return err
 	}
 
-	for _, page := range pages {
-		err = csvWriter.Write([]string{page.URL, page.H1,
+	// Use Range to iterate over sync.Map
+	pages.Range(func(key, value interface{}) bool {
+		// Type assert the value to PageData
+		page, ok := value.(PageData)
+		if !ok {
+			fmt.Printf("Warning: invalid page data for key %v\n", key)
+			return true // Continue iteration
+		}
+
+		// Write the record
+		err := csvWriter.Write([]string{
+			page.URL,
+			page.H1,
 			page.FirstParagraph,
 			strings.Join(page.OutgoingLinks, ";"),
 			strings.Join(page.ImageURLs, ";"),
 		})
 		if err != nil {
-			fmt.Printf("Error writing a record to csv file: %v", err)
+			fmt.Printf("Error writing record to csv file: %v\n", err)
+			// You might want to return false here to stop iteration on error
+			// return false
 		}
-	}
+
+		return true // Continue to next item
+	})
 
 	return nil
-
 }

--- a/extract_links_images.go
+++ b/extract_links_images.go
@@ -21,6 +21,7 @@ func getURLsFromHTML(htmlBody string, baseURL *url.URL) ([]string, error) {
 			parsedURL, err := url.Parse(val)
 			if err != nil {
 				fmt.Printf("Couldn't parse URL: %v", err)
+				return
 			}
 
 			absoluteURL := baseURL.ResolveReference(parsedURL)
@@ -47,6 +48,7 @@ func getImagesFromHTML(htmlBody string, baseURL *url.URL) ([]string, error) {
 			parsedURL, err := url.Parse(val)
 			if err != nil {
 				fmt.Printf("Couldn't parse URL: %v", err)
+				return
 			}
 
 			absoluteURL := baseURL.ResolveReference(parsedURL)

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"sync/atomic"
 )
 
 func main() {
@@ -45,7 +46,8 @@ func main() {
 	}
 
 	cfg := config{
-		pages:              make(map[string]PageData),
+		pages:              sync.Map{},
+		pageCount:          atomic.Int32{},
 		mu:                 &sync.Mutex{},
 		wg:                 &sync.WaitGroup{},
 		concurrencyControl: make(chan struct{}, maxConcurrency), //limit to 7
@@ -57,7 +59,7 @@ func main() {
 	cfg.wg.Wait()
 	fmt.Println("Crawling done, See results in csv...")
 
-	err = writeCSVReport(cfg.pages, "report.csv")
+	err = writeCSVReport(&cfg.pages, "report.csv")
 	if err != nil {
 		fmt.Printf("error writing csv report: %s\n", err)
 		os.Exit(1)


### PR DESCRIPTION
Instead of using a regular map with manually using the sync mutex , a sync.Map has been used. No performance metrics measured so , not entirely sure if there is any benefit to this change.